### PR TITLE
added Hg.identify

### DIFF
--- a/src/Hg.js
+++ b/src/Hg.js
@@ -174,6 +174,10 @@ class Hg {
   static async version(done) {
     return Command.runWithHandling('hg --version', undefined, undefined, done);
   }
+
+  async identify(remoteUrl, done) {
+    return Command.runWithHandling(`hg identify ${remoteUrl}`, undefined, undefined, done);
+  }
 }
 
 module.exports = Hg;

--- a/src/Hg.js
+++ b/src/Hg.js
@@ -175,6 +175,10 @@ class Hg {
     return Command.runWithHandling('hg --version', undefined, undefined, done);
   }
 
+  identify(remoteUrl, done) {
+    return this.constructor.identify(remoteUrl, done);
+  }
+
   static async identify(remoteUrl, done) {
     return Command.runWithHandling(`hg identify ${remoteUrl}`, undefined, undefined, done);
   }

--- a/src/Hg.js
+++ b/src/Hg.js
@@ -175,7 +175,7 @@ class Hg {
     return Command.runWithHandling('hg --version', undefined, undefined, done);
   }
 
-  async identify(remoteUrl, done) {
+  static async identify(remoteUrl, done) {
     return Command.runWithHandling(`hg identify ${remoteUrl}`, undefined, undefined, done);
   }
 }


### PR DESCRIPTION
I needed Hg.identify so that my code can check the validity of a remote repository url without cloning it. It's merely a proxy to the "hg identify http://url" command and my changes only involve adding a few lines to the exported Hg class - nothing removed.